### PR TITLE
Bugfix: Go to login page at startup

### DIFF
--- a/lib/blocs/authentication/bloc/authentication_bloc.dart
+++ b/lib/blocs/authentication/bloc/authentication_bloc.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:bloc/bloc.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
@@ -51,14 +49,21 @@ class AuthenticationBloc
     });
 
     // Handle authentication changes
-    on<AuthenticationUserChangedEvent>((event, emit) {
-      if (event.user == null) {
-        // User is signed out
-        emit(AuthenticationLoggedIn());
-      } else {
+    on<AuthenticationUserChangedEvent>((event, emit) async {
+      if (event.user?.uid != null) {
         // User is signed in
-        emit(AuthenticationLoggedOut());
+        SportUser? sportLoggedInUser =
+            await _userRepository.getUser(event.user?.uid ?? '');
+
+        if (sportLoggedInUser != null) {
+          sportUser = sportLoggedInUser;
+          emit(AuthenticationLoggedIn());
+          return;
+        }
       }
+
+      // The user is not valid or signed in
+      emit(AuthenticationLoggedOut());
     });
 
     // Emit our own auth state when the firebase auth state changes

--- a/lib/pages/sports_page.dart
+++ b/lib/pages/sports_page.dart
@@ -25,7 +25,7 @@ class SportsPage extends StatelessWidget {
           children: [
             Text(
               'Hello, ${authenticationBloc.sportUser?.name}',
-              style: TextStyle(fontSize: 24), // Optional: Adjust text style
+              style: const TextStyle(fontSize: 24), // Optional: Adjust text style
             ),
             const SizedBox(
                 height: 20), // Add some space between text and button


### PR DESCRIPTION
+ When the app loads, if the user has not logged in in Firebase, we were wrongly raising the AuthenticationLoggedIn event and causing the user to go to the home page directly before logging.
+ Fixed bug by fixing the AuthenticationUserChangedEvent handler to only raise the AuthenticationLoggedIn if the user is logged in and we got a valid user from firestore.

### Loading app before login
Wrongly takes the user to the /sports page
![image](https://github.com/user-attachments/assets/0c58335f-68ed-4d38-8a57-3393b3a36333)

### After this bugfix, the app loads on the login page
![image](https://github.com/user-attachments/assets/0072186d-0942-4f95-b93b-d27d3804c5ff)

### After we sign in, we get the correct user data
![image](https://github.com/user-attachments/assets/d2019f2f-9ee0-4868-8a0d-789a44112103)
