### PR TITLE
Add animated filled button

### DIFF
--- a/lib/blocs/authentication/location/location_bloc.dart
+++ b/lib/blocs/authentication/location/location_bloc.dart
@@ -148,7 +148,7 @@ class LocationBloc extends Bloc<LocationEvent, LocationState> {
       {required BuildContext context, Function? onCancel}) {
     return showDialog(
         context: context,
-        barrierDismissible: false,
+        barrierDismissible: true,
         builder: (context) {
           final GlobalKey<FormState> formKey = GlobalKey<FormState>();
           final TextEditingController textController = TextEditingController();

--- a/lib/pages/registration_confirmation_page.dart
+++ b/lib/pages/registration_confirmation_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:join_play/navigation/route_names.dart';
+import 'package:join_play/widgets/animated_filled_button.dart';
 import 'package:rive/rive.dart';
 import 'package:confetti/confetti.dart';
 
@@ -141,15 +142,30 @@ class _RegistrationConfirmationPageState
                 padding: const EdgeInsets.symmetric(horizontal: 16.0),
                 child: Column(
                   children: [
-                    FilledButton(
-                      onPressed: () {
+                    AnimatedFilledButton(
+                      onPressedOrCompleted: () {
                         context
                             .goNamed(RouteNames.myGames); // Navigate to /myGame
                       },
-                      child: const Text('Check my games'),
+                      buttonChild: Text('Check my games',
+                          style: Theme.of(context)
+                              .textTheme
+                              .titleMedium
+                              ?.copyWith(
+                                  color:
+                                      Theme.of(context).colorScheme.onPrimary, fontSize: 24)),
+                      width: 200,
+                      height: 50,
+                      duration: const Duration(seconds: 7, milliseconds: 500),
+                      backgroundColor: Theme.of(context)
+                          .colorScheme
+                          .primary
+                          .withOpacity(0.5),
+                      progressColor: Theme.of(context).colorScheme.primary,
                     ),
                     const SizedBox(height: 24),
-                    Text('Looking for more game?', style: Theme.of(context).textTheme.bodyMedium),
+                    Text('Looking for more game?',
+                        style: Theme.of(context).textTheme.bodyMedium),
                     TextButton(
                       onPressed: () {
                         context

--- a/lib/widgets/animated_filled_button.dart
+++ b/lib/widgets/animated_filled_button.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+
+/// A filled button that animates from left to right with a callback when pressed or completed.
+class AnimatedFilledButton extends StatefulWidget {
+  final double width;
+  final double height;
+  final Duration duration;
+  final Widget buttonChild;
+  final Color progressColor;
+  final Color backgroundColor;
+  final BorderRadius borderRadius;
+  final VoidCallback onPressedOrCompleted;
+
+  AnimatedFilledButton(
+      {super.key,
+      double? width,
+      double? height,
+      Duration? duration,
+      Color? progressColor,
+      Color? backgroundColor,
+      BorderRadius? borderRadius,
+      required this.buttonChild,
+      required this.onPressedOrCompleted})
+      : duration = duration ?? const Duration(seconds: 5),
+        width = width ?? 100,
+        height = height ?? 50,
+        progressColor = progressColor ?? Colors.blueAccent,
+        backgroundColor = backgroundColor ?? Colors.blueAccent.withOpacity(0.5),
+        borderRadius = borderRadius ?? BorderRadius.circular(32);
+
+  @override
+  State<AnimatedFilledButton> createState() {
+    return _AnimatedFilledButtonState();
+  }
+}
+
+class _AnimatedFilledButtonState extends State<AnimatedFilledButton>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _animationController;
+  late Animation<double> _widthAnimation;
+
+  late double height;
+  late double maxWidth = 150;
+  late double minWidth = 1;
+
+  // Animated width value
+  double currentWidth = 0;
+
+  // Determines if we have invoked the callback
+  bool _invokedCallback = false;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // Get height and width from the parameters
+    maxWidth = widget.width;
+    height = widget.height;
+
+    // Create animation controller
+    _animationController =
+        AnimationController(vsync: this, duration: widget.duration);
+
+    // Create tween to interpolate the animation into the width of the growing container
+    _widthAnimation = Tween<double>(begin: minWidth, end: maxWidth).animate(
+        CurvedAnimation(parent: _animationController, curve: Curves.easeOut));
+
+    // Route the user once the button is filled
+    _animationController.addStatusListener((AnimationStatus status) {
+      if (status == AnimationStatus.completed) {
+        // Invoke the callback
+        if (!_invokedCallback) {
+          widget.onPressedOrCompleted();
+          _invokedCallback = true;
+        }
+      }
+    });
+
+    // Update the width of the animated continer and render as the animation progresses.
+    _animationController.addListener(() {
+      setState(() => currentWidth = _widthAnimation.value);
+    });
+
+    // Start animation right away.
+    _animationController.forward();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Wrap everything on a dector for when the user has click the button invoke the callback.
+    return GestureDetector(
+      onTap: () {
+        if (!_invokedCallback) {
+          widget.onPressedOrCompleted();
+          _invokedCallback = true;
+        }
+      },
+      // We need to clip the extra outside the border.
+      // Use the ClipRRect component to cut what it outside the border of the button.
+      child: ClipRRect(
+        borderRadius: widget.borderRadius,
+        child: Stack(
+          children: [
+            // Filled container with the ligher color
+            Container(
+              width: maxWidth,
+              height: height,
+              decoration: BoxDecoration(
+                color: widget.backgroundColor,
+                borderRadius: widget.borderRadius,
+              ),
+            ),
+
+            // Anamited container with the darker color
+            Container(
+              width: currentWidth,
+              height: height,
+              decoration: BoxDecoration(
+                color: widget.progressColor,
+              ),
+            ),
+
+            // Clear container with the label of the button
+            SizedBox(
+              width: maxWidth,
+              height: height,
+              child: Center(child: widget.buttonChild),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
+ Added reusable widget called AniamtedFilledButton where we display a pill button that fills with another color from left to right.
+ Once the button is filled, it invoked the completed callback
+ The user can also click the button to invoke the callback before the progression completes.
+ For the registration confirmation animation, we use the animated button on the "Check my games" button, so this way the user is not stuck on the animation page for too long. The user can either click on the button or wait 7.5 seconds until the page will redirect you to the mygames page.

### Animated Filled Button
![image](https://github.com/user-attachments/assets/a574aa78-a9b0-43f0-b4fe-d343c9955027)

### Reusable Widget 
The widget looks like this by default, but you can use the parameters to customize the look and behavior of the button.

```dart
  // Use options in constructor to change the behavior
  AnimatedFilledButton(
      {super.key,
      double? width,
      double? height,
      Duration? duration,
      Color? progressColor,
      Color? backgroundColor,
      BorderRadius? borderRadius,
      required this.buttonChild,
      required this.onPressedOrCompleted})
```
![Screenshot 2024-12-02 at 11 49 13 PM](https://github.com/user-attachments/assets/cb1d6397-dfcb-42a0-8a18-ea79e71ebab1)

